### PR TITLE
Delete content types for Container and Media

### DIFF
--- a/Etch.OrchardCore.Widgets.csproj
+++ b/Etch.OrchardCore.Widgets.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.4.1-beta</Version>
+    <Version>0.4.2-beta</Version>
     <PackageId>Etch.OrchardCore.Widgets</PackageId>
     <Title>Etch OrchardCore Widgets</Title>
     <Authors>Etch</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,9 +4,8 @@
     Name = "Common Widgets",
     Author = "Etch",
     Website = "https://etchuk.com",
-    Version = "0.4.1"
+    Version = "0.4.2"
 )]
-
 [assembly: Feature(
     Id = "Etch.OrchardCore.Widgets",
     Name = "Common Widgets",

--- a/Migrations.cs
+++ b/Migrations.cs
@@ -1,4 +1,4 @@
-using OrchardCore.ContentManagement.Metadata;
+﻿using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.Data.Migration;
 using OrchardCore.Lists.Models;
@@ -67,17 +67,6 @@ namespace Etch.OrchardCore.Widgets
 
             #endregion Link
 
-            #region Container
-
-            _contentDefinitionManager.AlterTypeDefinition("Container", type => type
-                .WithPart("TitlePart")
-                .WithPart("Children", "FlowPart", part => part
-                    .WithDescription("Elements displayed within container")
-                    .WithDisplayName("Children"))
-                .Stereotype("Widget"));
-
-            #endregion Container
-
             #region Paragraph
 
             _contentDefinitionManager.AlterPartDefinition("ParagraphPart", part => part
@@ -89,25 +78,6 @@ namespace Etch.OrchardCore.Widgets
 
             #endregion Paragraph
 
-            #region Media
-
-            _contentDefinitionManager.AlterTypeDefinition("Media", type => type
-                .WithSetting("Description", "Displays media accompanied with text content")
-                .WithPart("TitlePart")
-                .WithPart("MediaItems", "BagPart", part => part
-                    .WithDisplayName("Media Items")
-                    .WithDescription("Images, video, embeds or HTML to be displayed")
-                    .WithSetting("DisplayType", "Detail")
-                    .ContainedContentTypes(new string[] { "Html" })
-                )
-                .WithPart("Body", "FlowPart", part => part
-                    .WithDisplayName("Body")
-                    .WithDescription("Content displayed alongside media")
-                )
-                .Stereotype("Widget"));
-
-            #endregion Media
-
             #region Html
 
             _contentDefinitionManager.AlterTypeDefinition("Html", type => type
@@ -118,7 +88,7 @@ namespace Etch.OrchardCore.Widgets
 
             #endregion Html
 
-            return 8;
+            return 9;
         }
 
         public int UpdateFrom1()

--- a/Migrations.cs
+++ b/Migrations.cs
@@ -1,7 +1,7 @@
 ﻿using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Settings;
-using OrchardCore.Lists.Models;
 using OrchardCore.Data.Migration;
+using OrchardCore.Lists.Models;
 
 namespace Etch.OrchardCore.Widgets
 {
@@ -28,7 +28,7 @@ namespace Etch.OrchardCore.Widgets
                 .WithDescription("Customise common attributes on HTML element.")
                 .WithDisplayName("HTML Attributes"));
 
-            #endregion
+            #endregion HtmlAttributes
 
             #region Section
 
@@ -43,7 +43,7 @@ namespace Etch.OrchardCore.Widgets
                     .WithDisplayName("Content"))
                 .Stereotype("Widget"));
 
-            #endregion
+            #endregion Section
 
             #region Heading
 
@@ -54,7 +54,7 @@ namespace Etch.OrchardCore.Widgets
                 .WithPart("HeadingPart")
                 .Stereotype("Widget"));
 
-            #endregion
+            #endregion Heading
 
             #region Link
 
@@ -65,7 +65,7 @@ namespace Etch.OrchardCore.Widgets
                 .WithPart("LinkPart")
                 .Stereotype("Widget"));
 
-            #endregion
+            #endregion Link
 
             #region Container
 
@@ -76,9 +76,9 @@ namespace Etch.OrchardCore.Widgets
                     .WithDisplayName("Children"))
                 .Stereotype("Widget"));
 
-            #endregion
+            #endregion Container
 
-            #region Paragraph 
+            #region Paragraph
 
             _contentDefinitionManager.AlterPartDefinition("ParagraphPart", part => part
                 .WithDescription("Properties for paragraph widget."));
@@ -87,7 +87,7 @@ namespace Etch.OrchardCore.Widgets
                 .WithPart("ParagraphPart")
                 .Stereotype("Widget"));
 
-            #endregion
+            #endregion Paragraph
 
             #region Media
 
@@ -106,17 +106,17 @@ namespace Etch.OrchardCore.Widgets
                 )
                 .Stereotype("Widget"));
 
-            #endregion
+            #endregion Media
 
             #region Html
 
             _contentDefinitionManager.AlterTypeDefinition("Html", type => type
-                .WithPart("HtmlBodyPart", 
+                .WithPart("HtmlBodyPart",
                     part => part.WithSetting("Editor", "Wysiwyg")
                 )
                 .Stereotype("Widget"));
 
-            #endregion
+            #endregion Html
 
             return 8;
         }
@@ -212,6 +212,13 @@ namespace Etch.OrchardCore.Widgets
 
             return 8;
         }
+
+        public int UpdarteFrom8()
+        {
+            _contentDefinitionManager.DeleteTypeDefinition("Container");
+            _contentDefinitionManager.DeleteTypeDefinition("Media");
+
+            return 9;
+        }
     }
 }
-

--- a/Migrations.cs
+++ b/Migrations.cs
@@ -1,4 +1,4 @@
-﻿using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.Data.Migration;
 using OrchardCore.Lists.Models;
@@ -215,8 +215,15 @@ namespace Etch.OrchardCore.Widgets
 
         public int UpdarteFrom8()
         {
-            _contentDefinitionManager.DeleteTypeDefinition("Container");
-            _contentDefinitionManager.DeleteTypeDefinition("Media");
+            if (_contentDefinitionManager.GetTypeDefinition("Container") != null)
+            {
+                _contentDefinitionManager.DeleteTypeDefinition("Container");
+            }
+
+            if (_contentDefinitionManager.GetTypeDefinition("Media") != null)
+            {
+                _contentDefinitionManager.DeleteTypeDefinition("Media");
+            }
 
             return 9;
         }


### PR DESCRIPTION
Media has been removed because the functionality within the admin area no longer works, this is a stop gap until we can get this replaced with a newer Image component (see #7)

Container isn't really used anymore within our workflows, and as such also isn't really needed.