### PR TITLE
Hide hero button if no text for label entered

### DIFF
--- a/Views/Widget-Hero.liquid
+++ b/Views/Widget-Hero.liquid
@@ -5,7 +5,9 @@
         <div class="hero">
             <div class="hero__body">
                 <h1 class="hero__title">{{ Model.ContentItem.Content.Hero.DisplayText.Text | raw }}</h1>
-                <a href="{{ Model.ContentItem.Content.Hero.CTAUrl.Text | href }}" class="btn__btn btn btn--primary">{{ Model.ContentItem.Content.Hero.CTALabel.Text | raw }}</a>
+                {% if Model.ContentItem.Content.Hero.CTALabel.Text != nil %}
+                    <a href="{{ Model.ContentItem.Content.Hero.CTAUrl.Text | href }}" class="btn__btn btn btn--primary">{{ Model.ContentItem.Content.Hero.CTALabel.Text | raw }}</a>
+                {% endif %}
             </div>
             
             {% if backgroundType == "embed" %}


### PR DESCRIPTION
I've done a few tests with this, such as entering a load of spaces in the admin area, and they get trimmed on saving and it gets reduced back to null 😄 