### PR TITLE
Wrap menu in `Banner` in `nav` element

### DIFF
--- a/Views/Widget-Banner.liquid
+++ b/Views/Widget-Banner.liquid
@@ -13,6 +13,8 @@
 
         <div class="header__nav-button js-nav-button">{{ Model.ContentItem.Content.Banner.MenuToggleButtonLabel.Text }}</div>
 
-        {% shape "menu", alias: mainMenuAlias %}
+        <nav class="nav" role="navigation">
+            {% shape "menu", alias: mainMenuAlias %}
+        </nav>
     </div>
 </header>


### PR DESCRIPTION
Updates to theme will remove rendering a `nav` element within the `Menu` shape and instead this should be handled by the parent, in this case the `Banner` but is commonly used in a `Footer` widget too.

https://github.com/EtchUK/Etch.OrchardCore.ThemeBoilerplate/commit/568e5eb4a34456deb0123f8fc3b61987d4f4f4ff