### PR TITLE
Add basic carousel widget

### DIFF
--- a/Recipes/definitions.recipe.json
+++ b/Recipes/definitions.recipe.json
@@ -531,6 +531,72 @@
               }
             }
           ]
+        },
+        {
+          "Name": "Carousel",
+          "DisplayName": "Carousel",
+          "Settings": {
+            "ContentTypeSettings": {
+              "Stereotype": "Widget"
+            },
+            "FullTextAspectSettings": {}
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "Carousel",
+              "Name": "Carousel",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "1"
+                }
+              }
+            },
+            {
+              "PartName": "TitlePart",
+              "Name": "TitlePart",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "0"
+                }
+              }
+            },
+            {
+              "PartName": "BagPart",
+              "Name": "Items",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "DisplayName": "Items",
+                  "Description": "Items included as slides within carousel.",
+                  "Position": "2"
+                },
+                "BagPartSettings": {
+                  "ContainedContentTypes": [
+                    "CarouselItem"
+                  ]
+                },
+                "ContentIndexSettings": {}
+              }
+            }
+          ]
+        },
+        {
+          "Name": "CarouselItem",
+          "DisplayName": "Carousel Item",
+          "Settings": {
+            "ContentTypeSettings": {},
+            "FullTextAspectSettings": {}
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "CarouselItem",
+              "Name": "CarouselItem",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "0"
+                }
+              }
+            }
+          ]
         }
       ],
       "ContentParts": [
@@ -1146,6 +1212,90 @@
                 },
                 "TextFieldSettings": {
                   "Hint": "Caption displayed to give description of embedded content."
+                },
+                "ContentIndexSettings": {}
+              }
+            }
+          ]
+        },
+        {
+          "Name": "Carousel",
+          "Settings": {},
+          "ContentPartFieldDefinitionRecords": [
+            {
+              "FieldName": "NumericField",
+              "Name": "SlideDuration",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Slide Duration",
+                  "Position": "0"
+                },
+                "NumericFieldSettings": {
+                  "Hint": "Number of seconds each slide should display for. If set to \"0\", the slides won't automatically change.",
+                  "Minimum": 0.0,
+                  "DefaultValue": "10"
+                },
+                "ContentIndexSettings": {}
+              }
+            }
+          ]
+        },
+
+        {
+          "Name": "CarouselItem",
+          "Settings": {},
+          "ContentPartFieldDefinitionRecords": [
+            {
+              "FieldName": "ResponsiveMediaField",
+              "Name": "BackgroundImage",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Background Image",
+                  "Position": "0"
+                },
+                "ResponsiveMediaFieldSettings": {
+                  "Breakpoints": "375, 425, 600, 768, 1024, 1280, 1440, 1920, 2560",
+                  "Hint": "Ensure all background images for each carousel item has the same dimensions to ensure the height of the carousel remains the same when changing the active item.",
+                  "FallbackData": "[]",
+                  "IsConfigured": true
+                },
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "TextField",
+              "Name": "Heading",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Heading",
+                  "Position": "1"
+                }
+              }
+            },
+            {
+              "FieldName": "TextField",
+              "Name": "CTALabel",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "CTA Label",
+                  "Position": "2"
+                }
+              }
+            },
+            {
+              "FieldName": "ContentPickerField",
+              "Name": "CTALinkTo",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "CTA Link To",
+                  "Position": "3"
+                },
+                "ContentPickerFieldSettings": {
+                  "Hint": "Select a content item within the site that the user will be navigated to.",
+                  "DisplayedContentTypes": [
+                    "Homepage",
+                    "Page"
+                  ]
                 },
                 "ContentIndexSettings": {}
               }

--- a/Views/Content-CarouselItem.liquid
+++ b/Views/Content-CarouselItem.liquid
@@ -1,0 +1,13 @@
+﻿{% assign linkedContent = Content.ContentItemId[Model.ContentItem.Content.CarouselItem.CTALinkTo.ContentItemIds[0]] %}
+
+<div class="card card--carousel">
+    <div class="card__body">
+        <h2 class="text--size-h1">{{ Model.ContentItem.Content.CarouselItem.Heading.Text | raw }}</h2>
+
+        {% if linkedContent %}
+            <p><a class="btn btn--secondary" href="{{ linkedContent | display_url }}">{{ Model.ContentItem.Content.CarouselItem.CTALabel.Text | raw }}</a></p>
+        {% endif %}
+    </div>
+
+    {{ Model.Background | shape_render }}
+</div>

--- a/Views/Widget-Carousel.liquid
+++ b/Views/Widget-Carousel.liquid
@@ -1,0 +1,42 @@
+﻿{% assign itemCount = Model.ContentItem.Content.Items.ContentItems | size %}
+{% assign loopMaxIndex = itemCount - 1 %}
+
+<div class="carousel js-carousel" data-duration="{{ Model.ContentItem.Content.Carousel.SlideDuration.Value * 1000 }}">
+    {% if itemCount > 1 %}
+        <button class="btn btn--icon carousel__previous-btn js-prev-btn">
+            <svg width="27" height="50" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.541 26.414L25.127 50l1.415-1.414L2.956 25 26.54 1.414 25.127 0 1.541 23.586l-.126-.127-1.414 1.415.126.126-.126.126 1.414 1.415.126-.127z" fill="#EEECEA" /></svg>
+            <span class="visuallyhidden">{{ "Previous" | t }}</span>
+        </button>
+
+        <button class="btn btn--icon carousel__next-btn js-next-btn">
+            <svg width="27" height="50" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.541 26.414L25.127 50l1.415-1.414L2.956 25 26.54 1.414 25.127 0 1.541 23.586l-.126-.127-1.414 1.415.126.126-.126.126 1.414 1.415.126-.127z" fill="#EEECEA" /></svg>
+            <span class="visuallyhidden">{{ "Next" | t }}</span>
+        </button>
+
+        <ul class="carousel__indicators">
+            {% for i in (0..loopMaxIndex) %}
+                {% if i == 0 %}
+                <li class="carousel__indicator is-active">
+                {% else %}
+                <li class="carousel__indicator">
+                {% endif %}
+                    <button class="btn btn--icon js-change-to-btn" data-index="{{ i }}">
+                        <span class="visuallyhidden">{{ "Change item to index" | t }} {{ i }}</span>
+                    </button>
+                </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+
+    <ul class="carousel__items js-carousel-items">
+        {% for i in (0..loopMaxIndex) %}
+            {% if i == 0 %}
+            <li class="carousel__item is-active">
+            {% else %}
+            <li class="carousel__item">
+            {% endif %}
+                {{ Model.ContentItem.Content.Items.ContentItems[i] | shape_build_display: "Detail" | shape_render }}
+            </li>
+        {% endfor %}
+    </ul>
+</div>


### PR DESCRIPTION
Add "Carousel" content type which contains a collection of "CarouselItem". "CarouselItem" contains a heading, CTA and a background image. Templates will render out mark up that marries up to styles & JS from our theme boilerplate.