### PR TITLE
Remove unnecessary role="banner" from header

### DIFF
--- a/Views/Widget-Banner.liquid
+++ b/Views/Widget-Banner.liquid
@@ -2,7 +2,7 @@
 
 {% assign mainMenuAlias = "alias:" | append: mainMenu.Content.AliasPart.Alias %}
 
-<header class="header" role="banner">
+<header class="header">
     <div class="header__content constrain constrain--wide">
         <a class="header__logo" href="{{ Request.PathBase }}/">
             <picture>


### PR DESCRIPTION
As this is assumed from the semantic header element. 

Validators won't throw an error for this but they do throw a warning and recommend removing it, as it adds unnecessary complexity for some screen readers. 

This does also raise the question of whether Widget-Banner is a good name for this, as the file would no longer have the word banner in it at all... 