### PR TITLE
Support responsive media field alt text

### DIFF
--- a/Etch.OrchardCore.Widgets.csproj
+++ b/Etch.OrchardCore.Widgets.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.11.0-rc2</Version>
+    <Version>0.11.1-rc2</Version>
     <PackageId>Etch.OrchardCore.Widgets</PackageId>
     <Title>Etch OrchardCore Widgets</Title>
     <Authors>Etch</Authors>

--- a/Etch.OrchardCore.Widgets.csproj
+++ b/Etch.OrchardCore.Widgets.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Etch.OrchardCore.Fields" Version="0.9.2-rc2" />
+    <PackageReference Include="Etch.OrchardCore.Fields" Version="0.10.2-rc2" />
     <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc2-13450" />
     <PackageReference Include="OrchardCore.ContentManagement.Display" Version="1.0.0-rc2-13450" />
     <PackageReference Include="OrchardCore.Flows" Version="1.0.0-rc2-13450" />

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@
     Name = "Common Widgets",
     Author = "Etch",
     Website = "https://etchuk.com",
-    Version = "0.11.0"
+    Version = "0.11.1"
 )]
 
 [assembly: Feature(

--- a/Recipes/definitions.recipe.json
+++ b/Recipes/definitions.recipe.json
@@ -868,6 +868,7 @@
                   "Position": "1"
                 },
                 "ResponsiveMediaFieldSettings": {
+                  "AllowMediaText": true,
                   "Breakpoints": "375, 425, 600, 768, 1024, 1280, 1440, 1920, 2560",
                   "Hint": "Image displayed as background of section.",
                   "FallbackData": "[]",
@@ -1296,6 +1297,7 @@
                   "DisplayName": "Background Image"
                 },
                 "ResponsiveMediaFieldSettings": {
+                  "AllowMediaText": true,
                   "Breakpoints": "375, 425, 600, 768, 1024, 1280, 1440, 1920, 2560",
                   "Hint": "Image displayed as background of hero.",
                   "Required": false
@@ -1567,6 +1569,7 @@
                   "Position": "0"
                 },
                 "ResponsiveMediaFieldSettings": {
+                  "AllowMediaText": true,
                   "Breakpoints": "375, 425, 600, 768, 1024, 1280, 1440, 1920, 2560",
                   "Hint": "Ensure all background images for each carousel item has the same dimensions to ensure the height of the carousel remains the same when changing the active item.",
                   "FallbackData": "[]",

--- a/Views/Hero-ResponsiveMediaField.liquid
+++ b/Views/Hero-ResponsiveMediaField.liquid
@@ -5,7 +5,7 @@
                 <source srcset="{{ source.Url }}" media="(min-width: {{ source.Breakpoint }}px)" />
             {% endfor %}
 
-            <img src="{{ item.SmallestImageUrl }}" />
+            <img src="{{ item.SmallestImageUrl }}" alt="{{ item.MediaText }}" />
         </picture>
     {% endfor %}
 {% endif %}


### PR DESCRIPTION
We've added support for alt text on responsive media fields. This PR enables the media text settings on all responsive media field and ensures the background media on hero renders any defined alt text.