### PR TITLE
v0.11.2

### DIFF
--- a/Drivers/HtmlAttributesPartDisplay.cs
+++ b/Drivers/HtmlAttributesPartDisplay.cs
@@ -16,7 +16,7 @@ namespace Etch.OrchardCore.Widgets.Drivers
             {
                 m.CssClasses = part.CssClasses;
                 m.Id = part.Id;
-            });
+            }).Location("Parts#HTML:25");
         }
 
         public async override Task<IDisplayResult> UpdateAsync(HtmlAttributesPart part, IUpdateModel updater)

--- a/Drivers/HtmlAttributesPartDisplay.cs
+++ b/Drivers/HtmlAttributesPartDisplay.cs
@@ -16,7 +16,7 @@ namespace Etch.OrchardCore.Widgets.Drivers
             {
                 m.CssClasses = part.CssClasses;
                 m.Id = part.Id;
-            }).Location("Parts#HTML:25");
+            }).Location("Parts#Attributes:25");
         }
 
         public async override Task<IDisplayResult> UpdateAsync(HtmlAttributesPart part, IUpdateModel updater)

--- a/Etch.OrchardCore.Widgets.csproj
+++ b/Etch.OrchardCore.Widgets.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.11.1-rc2</Version>
+    <Version>0.11.2-rc2</Version>
     <PackageId>Etch.OrchardCore.Widgets</PackageId>
     <Title>Etch OrchardCore Widgets</Title>
     <Authors>Etch</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@
     Name = "Common Widgets",
     Author = "Etch",
     Website = "https://etchuk.com",
-    Version = "0.11.1"
+    Version = "0.11.2"
 )]
 
 [assembly: Feature(

--- a/Migrations.cs
+++ b/Migrations.cs
@@ -1,8 +1,6 @@
 ﻿using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.Data.Migration;
-using OrchardCore.Recipes.Services;
-using System.Threading.Tasks;
 
 namespace Etch.OrchardCore.Widgets
 {
@@ -10,12 +8,12 @@ namespace Etch.OrchardCore.Widgets
     {
         private readonly IContentDefinitionManager _contentDefinitionManager;
 
-        public Migrations(IContentDefinitionManager contentDefinitionManager, IRecipeMigrator recipeMigrator)
+        public Migrations(IContentDefinitionManager contentDefinitionManager)
         {
             _contentDefinitionManager = contentDefinitionManager;
         }
 
-        public int CreateAsync()
+        public int Create()
         {
             #region Html Attributes
 

--- a/Views/Widget-Image.liquid
+++ b/Views/Widget-Image.liquid
@@ -3,7 +3,7 @@
 
 {% assign linkTo = Model.ContentItem.Content.Image.LinkTo.Text %}
 
-{% if linkTo != nill %}
+{% if linkTo != nil %}
     <a href="{{ linkTo }}">
         {% if Model.ContentItem.Content.HtmlAttributesPart != null %}
             <img {% if id != null %} id="{{ id }}" {% endif %} {% if cssClasses != null %} class="{{ cssClasses }}" {% endif %} src="{{ Model.ContentItem.Content.Image.Image.Paths[0] | asset_url }}" alt="{{ Model.ContentItem.Content.Image.AlternateText.Text }}" />

--- a/Views/Widget-Section.liquid
+++ b/Views/Widget-Section.liquid
@@ -42,7 +42,7 @@
     {% assign cssClasses = ' section--feature' | prepend: cssClasses %}
 {% endif %}
 
-<section class="{{ cssClasses }}">
+<section {% if id != nil %} id="{{ id }}" {% endif %} class="{{ cssClasses }}">
     {% if contentWidth != 'full' %}
     <div class="section__content {{ constrainClasses }}">
         {{ Model.Content.Content | shape_render }}


### PR DESCRIPTION
- Fix migration not creating `HtmlAttributesPart`
- Display `HtmlAttributesPart` within "Attributes" tab