### PR TITLE
Use lazy loading on `iframe`

### DIFF
--- a/Recipes/definitions.recipe.json
+++ b/Recipes/definitions.recipe.json
@@ -1972,6 +1972,21 @@
                 },
                 "ContentIndexSettings": {}
               }
+            },
+            {
+              "FieldName": "BooleanField",
+              "Name": "LazyLoad",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Lazy Load",
+                  "Position": "8"
+                },
+                "BooleanFieldSettings": {
+                  "Hint": "Load iframe when it's scrolled in to view which saves data, speeds up the loading of other parts of the page, and reduces memory usage however can cause layout shifts.",
+                  "Label": "Lazy Load"
+                },
+                "ContentIndexSettings": {}
+              }
             }
           ]
         },

--- a/Views/Widget-Embed.liquid
+++ b/Views/Widget-Embed.liquid
@@ -12,7 +12,7 @@
 
 <div {% if id != null %}id="{{ id }}"{% endif %} class="{{ cssClasses }} {{ Model.ContentItem | animation_css }}" style="{{ styles }} {{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}>
 	<div class="embed__source">
-		<iframe src="{{ Model.ContentItem.Content.Embed.Source.Text }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+		<iframe src="{{ Model.ContentItem.Content.Embed.Source.Text }}" loading="lazy" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 	</div>
 
 	{% if Model.ContentItem.Content.Embed.Caption.Text %}

--- a/Views/Widget-Hero.liquid
+++ b/Views/Widget-Hero.liquid
@@ -65,7 +65,7 @@
         <div class="hero__media">
             <div class="embed embed--ratio-16-9">
 				<div class="embed__source">
-					<iframe src="{{ Model.ContentItem.Content.Hero.BackgroundEmbed.Text }}" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
+					<iframe src="{{ Model.ContentItem.Content.Hero.BackgroundEmbed.Text }}" loading="lazy" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
 				</div>
             </div>
         </div>

--- a/Views/Widget-Hero.liquid
+++ b/Views/Widget-Hero.liquid
@@ -56,6 +56,10 @@
     {% assign styles = styles | append: backgroundColour %}
 {% endif %}
 
+{% if Model.ContentItem.Content.Hero.LazyLoad.Value %}
+     {% assign loading = "lazy" %}
+{% endif %}
+
 <section {% if id != nil %} id="{{ id }}" {% endif %} class="{{ cssClasses }} {{ Model.ContentItem | animation_css }}" style="{{ styles }} {{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}>
     <div class="hero__body {{ constrainClasses }}">
         {{ Model.Content.Content | shape_render }}
@@ -65,7 +69,7 @@
         <div class="hero__media">
             <div class="embed embed--ratio-16-9">
 				<div class="embed__source">
-					<iframe src="{{ Model.ContentItem.Content.Hero.BackgroundEmbed.Text }}" loading="lazy" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
+					<iframe src="{{ Model.ContentItem.Content.Hero.BackgroundEmbed.Text }}" loading="{{ loading | default: "eager" }}" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
 				</div>
             </div>
         </div>

--- a/placement.json
+++ b/placement.json
@@ -53,6 +53,13 @@
       ]
     },
     {
+      "place": "Parts#Background:16",
+      "differentiator": "Hero-LazyLoad",
+      "contentType": [
+        "Hero"
+      ]
+    },
+    {
       "place": "Parts#Layout:1",
       "differentiator": "Hero-PullUp",
       "contentType": [


### PR DESCRIPTION
This affects the "Embed" and "Hero" widgets. Additionally removed `frameborder` as it's obsolete in HTML5.