### PR TITLE
Add gallery widget

### DIFF
--- a/Recipes/definitions.recipe.json
+++ b/Recipes/definitions.recipe.json
@@ -1132,6 +1132,110 @@
               }
             }
           ]
+        },
+        {
+          "Name": "Gallery",
+          "DisplayName": "Gallery",
+          "Settings": {
+            "ContentTypeSettings": {
+              "Stereotype": "Widget"
+            },
+            "FullTextAspectSettings": {},
+            "Category": "Content",
+            "Description": "Display a gallery of media items (images and videos)",
+            "Icon": "images"
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "Gallery",
+              "Name": "Gallery",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "2"
+                }
+              }
+            },
+            {
+              "PartName": "ColumnablePart",
+              "Name": "ColumnablePart",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "3"
+                }
+              }
+            },
+            {
+              "PartName": "TitlePart",
+              "Name": "TitlePart",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "0"
+                }
+              }
+            },
+            {
+              "PartName": "BagPart",
+              "Name": "Items",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "DisplayName": "Items",
+                  "Description": "Specify items for this gallery",
+                  "Position": "1"
+                },
+                "BagPartSettings": {
+                  "ContainedContentTypes": [
+                    "GalleryEmbedItem",
+                    "GalleryMediaItem"
+                  ]
+                },
+                "ContentIndexSettings": {}
+              }
+            }
+          ]
+        },
+        {
+          "Name": "GalleryMediaItem",
+          "DisplayName": "Gallery Media Item",
+          "Settings": {
+            "ContentTypeSettings": {},
+            "FullTextAspectSettings": {},
+            "Category": "Content",
+            "Description": "Add an image to a gallery",
+            "Icon": "image"
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "GalleryMediaItem",
+              "Name": "GalleryMediaItem",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "0"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "Name": "GalleryEmbedItem",
+          "DisplayName": "Gallery Embed Item",
+          "Settings": {
+            "ContentTypeSettings": {},
+            "FullTextAspectSettings": {},
+            "Category": "Content",
+            "Description": "Add a video to a gallery",
+            "Icon": "video"
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "GalleryEmbedItem",
+              "Name": "GalleryEmbedItem",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "0"
+                }
+              }
+            }
+          ]
         }
       ],
       "ContentParts": [
@@ -3061,6 +3165,88 @@
                   "Hint": "Specify a unique ID for this item (Optional)"
                 },
                 "ContentIndexSettings": {}
+              }
+            }
+          ]
+        },
+        {
+          "Name": "GalleryMediaItem",
+          "Settings": {},
+          "ContentPartFieldDefinitionRecords": [
+            {
+              "FieldName": "MediaField",
+              "Name": "Image",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Image",
+                  "Position": "0"
+                },
+                "MediaFieldSettings": {
+                  "Multiple": false
+                }
+              }
+            },
+            {
+              "FieldName": "TextField",
+              "Name": "AltText",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Alt Text",
+                  "Position": "1"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "Name": "GalleryEmbedItem",
+          "Settings": {},
+          "ContentPartFieldDefinitionRecords": [
+            {
+              "FieldName": "TextField",
+              "Name": "EmbedURL",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Embed URL",
+                  "Position": "0"
+                },
+                "TextFieldSettings": {
+                  "Hint": "Specify a Vimeo or YouTube Embed URL, e.g https://www.youtube.com/embed/TorVk3Hxm7Q"
+                },
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "MediaField",
+              "Name": "ThumbnailImage",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Thumbnail Image",
+                  "Position": "2"
+                },
+                "MediaFieldSettings": {
+                  "Multiple": false
+                }
+              }
+            },
+            {
+              "FieldName": "TextField",
+              "Name": "Title",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Title",
+                  "Position": "1"
+                }
+              }
+            },
+            {
+              "FieldName": "TextField",
+              "Name": "ThumbnailAltText",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Thumbnail Alt Text",
+                  "Position": "3"
+                }
               }
             }
           ]

--- a/Views/Content-GalleryEmbedItem.liquid
+++ b/Views/Content-GalleryEmbedItem.liquid
@@ -1,0 +1,5 @@
+<li class="gallery__item gallery__item--embed">
+    <a class="gallery__item-link" href="{{ Model.ContentItem.Content.GalleryEmbedItem.EmbedURL.Text }}">
+        <img class="gallery__item-thumb" src="{{ Model.ContentItem.Content.GalleryEmbedItem.ThumbnailImage.Paths[0] | asset_url | resize_url: width: 1280 }}" title="{{ Model.ContentItem.Content.GalleryEmbedItem.Title.Text }}" alt="{{ Model.ContentItem.Content.GalleryEmbedItem.ThumbnailAltText.Text }}" />
+    </a>
+</li>

--- a/Views/Content-GalleryMediaItem.liquid
+++ b/Views/Content-GalleryMediaItem.liquid
@@ -1,0 +1,5 @@
+<li class="gallery__item gallery__item--media">
+    <a class="gallery__item-link" href="{{ Model.ContentItem.Content.GalleryMediaItem.Image.Paths[0] | asset_url| resize_url: width: 2560 }}">
+        <img class="gallery__item-thumb" src="{{ Model.ContentItem.Content.GalleryMediaItem.Image.Paths[0] | asset_url| resize_url: width: 1280 }}" title="{{ Model.ContentItem.Content.GalleryMediaItem.AltText.Text }}" alt="{{ Model.ContentItem.Content.GalleryMediaItem.AltText.Text }}" />
+    </a>
+</li>

--- a/Views/Widget-Gallery.liquid
+++ b/Views/Widget-Gallery.liquid
@@ -1,0 +1,11 @@
+{% assign items = Model.ContentItem.Content.Items.ContentItems %}
+{% assign itemCount = items | size %}
+{% assign cols = Model.ContentItem.Content.ColumnablePart.Columns.Text %}
+
+{% if itemCount > 0 %}
+    <ul class="gallery gallery--{{cols}}-cols js-gallery">
+        {% for item in items %}
+            {{ item | shape_build_display: "Detail" | shape_render }}
+        {% endfor %}
+    </ul>
+{% endif %}


### PR DESCRIPTION
In a bid to sunset the separate gallery module, here's a simpler gallery as part of the widgets module that also resolves some longstanding issues (it's columnable and has alt text and appropriate width/height behaviour for flexible shaped images). There's an adjacent PR to the theme boilerplate for the required style changes.

Please note that once released, we should remove the existing gallery module from the siteboilerplate to remove conflicts