### PR TITLE
Change animation timings (duration & delay) to milliseconds

### DIFF
--- a/Filters/AnimationStyles.cs
+++ b/Filters/AnimationStyles.cs
@@ -35,12 +35,12 @@ namespace Etch.OrchardCore.Widgets.Filters
 
             if (animationPart.Delay.HasValue)
             {
-                styles.Add($"--animationDelay: {animationPart.Delay}s;");
+                styles.Add($"--animationDelay: {animationPart.Delay}ms;");
             }
 
             if (animationPart.Duration.HasValue)
             {
-                styles.Add($"--animationDuration: {animationPart.Duration}s;");
+                styles.Add($"--animationDuration: {animationPart.Duration}ms;");
             }
 
             return new ValueTask<FluidValue>(new StringValue(string.Join(" ", styles)));

--- a/Migrations.cs
+++ b/Migrations.cs
@@ -179,8 +179,8 @@ namespace Etch.OrchardCore.Widgets
                     {
                         DefaultValue = "600",
                         Minimum = 0,
-                        Hint = "Length of animation in seconds.",
-                        Scale = 2
+                        Hint = "Length of animation in milliseconds.",
+                        Scale = 0
                     })
                 )
                 .WithField("Timing", field => field
@@ -215,8 +215,8 @@ namespace Etch.OrchardCore.Widgets
                     {
                         DefaultValue = "0",
                         Minimum = 0,
-                        Hint = "Number of seconds to delay start of animation.",
-                        Scale = 2
+                        Hint = "Number of milliseconds to delay start of animation.",
+                        Scale = 0
                     })
                 )
                 .WithField("Repeat", field => field


### PR DESCRIPTION
Found random issues with how decimals are being rendered, especially when the page is using a different culture. To avoid this and give greater control, the unit for duration & delay now represents the length in milliseconds.