### PR TITLE
Refactor widget heading markup to avoid `if` statement for rendering element

### DIFF
--- a/Views/Widget-Heading.liquid
+++ b/Views/Widget-Heading.liquid
@@ -1,10 +1,13 @@
-{% assign id = Model.ContentItem.Content.HtmlAttributesPart.Id %}
-{% assign cssClasses = Model.ContentItem.Content.HtmlAttributesPart.CssClasses %}
+{% assign id = text | slugify %}
+{% assign cssClasses = "" %}
 {% assign level = Model.ContentItem.Content.Heading.Level.Text %}
 {% assign text = Model.ContentItem.Content.Heading.Text.Text %}
 
 {% if Model.ContentItem.Content.HtmlAttributesPart != null %}
-    <h{{ level }} {% if id != null %} id="{{ id }}" {% endif %} class="{{ cssClasses }} {{ Model.ContentItem | animation_css }}" style="{{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}">{{ text }}</h{{ level }}>
-{% else %}
-    <h{{ level }} id="{{ text | slugify }}" class="{{ Model.ContentItem | animation_css }}" style="{{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}>{{ text }}</h{{ level }}>
+    {% assign id = Model.ContentItem.Content.HtmlAttributesPart.Id %}
+    {% assign cssClasses = Model.ContentItem.Content.HtmlAttributesPart.CssClasses %}
 {% endif %}
+
+<h{{ level }} {% if id != null %} id="{{ id }}" {% endif %} class="{{ cssClasses }} {{ Model.ContentItem | animation_css }}" style="{{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}>
+    {{ text }}
+</h{{ level }}>


### PR DESCRIPTION
Move checking whether `HtmlAttributesPart` is present out of the rendering to avoid a lot of duplication on how the element is rendered.