### PR TITLE
Adding "Skip" to Content Feed

### DIFF
--- a/Recipes/definitions.recipe.json
+++ b/Recipes/definitions.recipe.json
@@ -3039,6 +3039,21 @@
                   "Position": "1"
                 }
               }
+            },
+            {
+              "FieldName": "NumericField",
+              "Name": "Skip",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Skip",
+                  "Position": "5"
+                },
+                "NumericFieldSettings": {
+                  "Hint": "Number of items to skip. For example, if you have the 3 most recent items in a separate feed somewhere further up on the page, you may wish to skip 3.",
+                  "Minimum": 0.0
+                },
+                "ContentIndexSettings": {}
+              }
             }
           ]
         },

--- a/Views/Widget-ContentFeed.liquid
+++ b/Views/Widget-ContentFeed.liquid
@@ -1,10 +1,12 @@
 ﻿{% assign pageSize = Model.ContentItem.Content.ContentFeed.PageSize.Value %}
+{% assign skip = Model.ContentItem.Content.ContentFeed.Skip.Value %}
 {% assign fetchCount = pageSize | plus: 1 %}
 
 {% assign paging = Model.ContentItem.Content.ContentFeed.Paging.Value %}
 
 {% assign page = Request.Query["page"] | first | at_least: 1 %}
-{% assign from = page | times: pageSize | minus: pageSize  | at_least: 0 %}
+{% assign from = page | times: pageSize | minus: pageSize | plus: skip | at_least: 0 %}
+{% assign paginationStartPoint = 0 | plus: skip %}
 
 {% assign query = Model.ContentItem.Content.ContentFeed.Items.Value %}
 {% assign items = Queries[query] | query: size: fetchCount, from: from %}
@@ -73,7 +75,7 @@
 
         {% if paging %}
             <ul class="content-feed__pager pager margin--bottom-large">
-                {% if from > 0 %}
+                {% if from > paginationStartPoint %}
                     {% assign prevPage = page | minus: 1 %}
                     <li>
                         <a href="{{ pageUrl | append: "?page=" | append: prevPage }}">{{ "Newer posts" | t}}</a>


### PR DESCRIPTION
As seen/used on a recent project, to allow multiple content feeds, driven by the same query, on one page without duplication of content