### PR TITLE
Add "LinkVisualPart" for defining style of links

### DIFF
--- a/Etch.OrchardCore.Widgets.csproj
+++ b/Etch.OrchardCore.Widgets.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <PackageId>Etch.OrchardCore.Widgets</PackageId>
     <Title>Etch OrchardCore Widgets</Title>
     <Authors>Etch</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@
     Name = "Common Widgets",
     Author = "Etch",
     Website = "https://etchuk.com",
-    Version = "1.3.0"
+    Version = "1.4.0"
 )]
 
 [assembly: Feature(

--- a/Migrations.cs
+++ b/Migrations.cs
@@ -282,5 +282,44 @@ namespace Etch.OrchardCore.Widgets
 
             return 7;
         }
+
+        public int UpdateFrom7()
+        {
+            _contentDefinitionManager.AlterPartDefinition("LinkVisualPart", part => part
+               .Attachable()
+               .WithDescription("Define visual properties for a link.")
+               .WithDisplayName("Link Visual")
+               .WithField("Style", field => field
+                   .OfType(nameof(TextField))
+                   .WithDisplayName("Style")
+                   .WithPosition("1")
+                   .WithEditor("PredefinedList")
+                   .WithSettings(new TextFieldSettings
+                   {
+                       Hint = "Control the style of the link"
+                   })
+                   .WithSettings(new TextFieldPredefinedListEditorSettings
+                   {
+                       Editor = EditorOption.Dropdown,
+                       Options = new ListValueOption[] {
+                           new ListValueOption {
+                               Name = "Default",
+                               Value = string.Empty
+                           },
+                           new ListValueOption {
+                               Name = "Primary Button",
+                               Value = "btn--primary"
+                           },
+                           new ListValueOption {
+                               Name = "Secondary Button",
+                               Value = "btn--secondary"
+                           }
+                       }
+                   })
+               )
+            );
+
+            return 8;
+        }
     }
 }

--- a/Recipes/definitions.recipe.json
+++ b/Recipes/definitions.recipe.json
@@ -79,6 +79,15 @@
                   "Position": "0"
                 }
               }
+            },
+            {
+              "PartName": "LinkVisualPart",
+              "Name": "LinkVisualPart",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "1"
+                }
+              }
             }
           ]
         },
@@ -1753,37 +1762,6 @@
                   "Label": "Open in new Window"
                 },
                 "ContentIndexSettings": {}
-              }
-            },
-            {
-              "FieldName": "TextField",
-              "Name": "Style",
-              "Settings": {
-                "ContentPartFieldSettings": {
-                  "DisplayName": "Style",
-                  "Editor": "PredefinedList"
-                },
-                "TextFieldSettings": {
-                  "Hint": "Define appearance of link."
-                },
-                "TextFieldPredefinedListEditorSettings": {
-                  "Options": [
-                    {
-                      "name": "Default",
-                      "value": "default"
-                    },
-                    {
-                      "name": "Primary Button",
-                      "value": "btn--primary"
-                    },
-                    {
-                      "name": "Secondary Button",
-                      "value": "btn--secondary"
-                    }
-                  ],
-                  "Editor": 1,
-                  "DefaultValue": "default"
-                }
               }
             }
           ]

--- a/Recipes/definitions.recipe.json
+++ b/Recipes/definitions.recipe.json
@@ -4,7 +4,7 @@
   "description": "Creates content definitions for common widgets used to put together web pages.",
   "author": "Etch",
   "website": "https://etchuk.com",
-  "version": "1.1.1",
+  "version": "1.4.0",
   "issetuprecipe": false,
   "categories": ["Content"],
   "tags": ["etch"],

--- a/Views/Widget-Link.liquid
+++ b/Views/Widget-Link.liquid
@@ -1,9 +1,15 @@
 {% assign linkUrl = Model.ContentItem.Content.Link.Url.Text %}
 {% assign text = Model.ContentItem.Content.Link.Text.Text %}
 {% assign openInNewWindow = Model.ContentItem.Content.Link.OpenInNewWindow.Value %}
-{% assign style = Model.ContentItem.Content.Link.Style.Text %}
 {% assign cssClasses = '' %}
 {% assign onClickEvent = Model.ContentItem.Content.JavaScriptEventsPart.OnClick.Value %}
+
+{% comment %} "Style" field is obsolete but remains for backwards compatibility {% endcomment %}
+{% assign style = Model.ContentItem.Content.Link.Style.Text %}
+
+{% if Model.ContentItem.Content.LinkVisualPart.Style.Text %}
+    {% assign style = Model.ContentItem.Content.LinkVisualPart.Style.Text %}
+{% endif %}
 
 {% if style != null and style != 'default' %}
     {% assign cssClasses = 'btn ' | append: style %}


### PR DESCRIPTION
New part contains a "Style" dropdown and has been attached to the `Link` widget, which no longer contains a "Style" field. To prevent existing sites from breaking, the template will use the "Style" field and then use the new part if it contains a value.