### PR TITLE
Standardise quote html

### DIFF
--- a/Views/Widget-Blockquote.liquid
+++ b/Views/Widget-Blockquote.liquid
@@ -1,10 +1,18 @@
 {% assign id = Model.ContentItem.Content.HtmlAttributesPart.Id %}
-{% assign cssClasses = Model.ContentItem.Content.HtmlAttributesPart.CssClasses %}
+{% assign cssClasses = "styled-quote " | append: Model.ContentItem.Content.HtmlAttributesPart.CssClasses %}
 {% assign source = Model.ContentItem.Content.Blockquote.Source.Text %}
 
-<blockquote {% if id != null %} id="{{ id }}" {% endif %} class="{{ cssClasses }} {{ Model.ContentItem | animation_css }}" style="{{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}" />
-    {{ Model.Content.QuoteContent | shape_render }}
-</blockquote>
-{% if source != null %}
-    <cite>{{ source }}</cite>
-{% endif %}
+{% comment %} Per the spec, blockquote should only contain direct quote content {% endcomment %}
+{% comment %} https://www.w3.org/TR/html5-author/the-blockquote-element.html {% endcomment %}
+
+<figure {% if id != null %} id="{{ id }}" {% endif %} class="{{ cssClasses }} {{ Model.ContentItem | animation_css }}" style="{{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}">
+    <blockquote class="styled-quote__copy">
+        {{ Model.Content.QuoteContent | shape_render }}
+    </blockquote>
+
+    {% if source != null %}
+        <figcaption class="styled-quote__source">
+            {{ source }}
+        </figcaption>
+    {% endif %}
+</figure>


### PR DESCRIPTION
To bring our multiple quote outputs into one standardised default output, which meets the HTML spec. As part of this, blockquote's default styles are being simplified, and styled-quote is being created to house any complex styling requirements that might arise rather than putting a lot of stuff into the tag based CSS. Adjacent commits will be made to both ThemeBoilerplate and Blocks to match this new expectation.