### PR TITLE
Add Visual Level option to Headings

### DIFF
--- a/Recipes/definitions.recipe.json
+++ b/Recipes/definitions.recipe.json
@@ -1815,7 +1815,7 @@
                   "Editor": "PredefinedList"
                 },
                 "TextFieldSettings": {
-                  "Hint": "Importance of the heading, where the lower the value the more important the heading.",
+                  "Hint": "Importance of the heading. The lower the value, the more important the heading.",
                   "Required": true
                 },
                 "TextFieldPredefinedListEditorSettings": {
@@ -1847,6 +1847,55 @@
                   ],
                   "Editor": 1,
                   "DefaultValue": null
+                },
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "TextField",
+              "Name": "VisualLevel",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Visual Level",
+                  "Editor": "PredefinedList"
+                },
+                "TextFieldSettings": {
+                  "Hint": "By default, headings are styled according to their level. You can use this field to make them look like an alternative level of importance if necessary.",
+                  "Required": true
+                },
+                "TextFieldPredefinedListEditorSettings": {
+                  "Options": [
+                    {
+                      "name": "Match Level",
+                      "value": ""
+                    },
+                    {
+                      "name": "1",
+                      "value": "1"
+                    },
+                    {
+                      "name": "2",
+                      "value": "2"
+                    },
+                    {
+                      "name": "3",
+                      "value": "3"
+                    },
+                    {
+                      "name": "4",
+                      "value": "4"
+                    },
+                    {
+                      "name": "5",
+                      "value": "5"
+                    },
+                    {
+                      "name": "6",
+                      "value": "6"
+                    }
+                  ],
+                  "Editor": 1,
+                  "DefaultValue": ""
                 },
                 "ContentIndexSettings": {}
               }

--- a/Views/Widget-Heading.liquid
+++ b/Views/Widget-Heading.liquid
@@ -1,11 +1,16 @@
 {% assign id = text | slugify %}
-{% assign cssClasses = "" %}
+{% assign cssClasses = "heading" %}
 {% assign level = Model.ContentItem.Content.Heading.Level.Text %}
+{% assign visualLevel = Model.ContentItem.Content.Heading.VisualLevel.Text %}
 {% assign text = Model.ContentItem.Content.Heading.Text.Text %}
 
 {% if Model.ContentItem.Content.HtmlAttributesPart != null %}
     {% assign id = Model.ContentItem.Content.HtmlAttributesPart.Id %}
-    {% assign cssClasses = Model.ContentItem.Content.HtmlAttributesPart.CssClasses %}
+    {% assign cssClasses = cssClasses | append: " " | append: Model.ContentItem.Content.HtmlAttributesPart.CssClasses %}
+{% endif %}
+
+{% if visualLevel != nil %}
+    {% assign cssClasses = cssClasses | append: " text--h" | append: visualLevel %}
 {% endif %}
 
 <h{{ level }} {% if id != null %} id="{{ id }}" {% endif %} class="{{ cssClasses }} {{ Model.ContentItem | animation_css }}" style="{{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}>


### PR DESCRIPTION
Allowing for semantic level and visual appearance to diverge if desired - e.g make h3's that look like h2's or vice versa