### PR TITLE
Fix Visual Level saving issue

### DIFF
--- a/Recipes/definitions.recipe.json
+++ b/Recipes/definitions.recipe.json
@@ -1860,8 +1860,7 @@
                   "Editor": "PredefinedList"
                 },
                 "TextFieldSettings": {
-                  "Hint": "By default, headings are styled according to their level. You can use this field to make them look like an alternative level of importance if necessary.",
-                  "Required": true
+                  "Hint": "By default, headings are styled according to their level. You can use this field to make them look like an alternative level of importance if necessary."
                 },
                 "TextFieldPredefinedListEditorSettings": {
                   "Options": [


### PR DESCRIPTION
When set to required, you can't save a Heading with "Match Level" as the option, because it is empty. Match Level is also the default so this will occur frequently until fixed. A temporary workaround is to pick the desired visual level on every heading but we'll want to get this sorted before major content population because it's annoying!