### PR TITLE
Update carousel widget to use new times filter

### DIFF
--- a/Views/Widget-Carousel.liquid
+++ b/Views/Widget-Carousel.liquid
@@ -1,7 +1,7 @@
 ﻿{% assign itemCount = Model.ContentItem.Content.Items.ContentItems | size %}
 {% assign loopMaxIndex = itemCount | minus: 1 %}
 
-<div class="carousel js-carousel" data-duration="{{ Model.ContentItem.Content.Carousel.SlideDuration.Value * 1000 }}">
+<div class="carousel js-carousel" data-duration="{{ Model.ContentItem.Content.Carousel.SlideDuration.Value | times: 1000 }}">
     {% if itemCount > 1 %}
         <button class="btn btn--icon carousel__previous-btn js-prev-btn">
             <svg width="27" height="50" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path clip-rule="evenodd" d="M1.541 26.414L25.127 50l1.415-1.414L2.956 25 26.54 1.414 25.127 0 1.541 23.586l-.126-.127-1.414 1.415.126.126-.126.126 1.414 1.415.126-.127z" /></svg>


### PR DESCRIPTION
I've looked through the rest of the liquid file and there aren't any other math references, so this should be the last fix. Annoying that we had to do two updates.