### PR TITLE
Add 100vh option to hero

### DIFF
--- a/Recipes/definitions.recipe.json
+++ b/Recipes/definitions.recipe.json
@@ -2440,6 +2440,10 @@
                     {
                       "name": "4:1 (Ultrawide)",
                       "value": "4-1"
+                    },
+                    {
+                      "name": "100% (Use 16:9 asset)",
+                      "value": "100vh"
                     }
                   ],
                   "Editor": 1,
@@ -2494,6 +2498,10 @@
                     {
                       "name": "4:1 (Ultrawide)",
                       "value": "4-1"
+                    },
+                    {
+                      "name": "100% (Use 16:9 asset)",
+                      "value": "100vh"
                     }
                   ],
                   "Editor": 1,
@@ -2548,6 +2556,10 @@
                     {
                       "name": "4:1 (Ultrawide)",
                       "value": "4-1"
+                    },
+                    {
+                      "name": "100% (Use 16:9 asset)",
+                      "value": "100vh"
                     }
                   ],
                   "Editor": 1,


### PR DESCRIPTION
An adjacent change has been made to themeboilerplate which styles this correctly. It allows a video (or image, as long as it's 16:9) hero background to fill the viewport height.