### PR TITLE
Card widget template/definition standardisation

### DIFF
--- a/Recipes/definitions.recipe.json
+++ b/Recipes/definitions.recipe.json
@@ -2613,6 +2613,15 @@
                   "DisplayName": "CTA Url"
                 }
               }
+            },
+            {
+              "FieldName": "TextField",
+              "Name": "MetaText",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Meta Text"
+                }
+              }
             }
           ]
         },

--- a/Views/Widget-Card.liquid
+++ b/Views/Widget-Card.liquid
@@ -1,4 +1,5 @@
-{% assign url = Model.ContentItem.Content.Card.URL.Text %}
+{% assign url = Model.ContentItem.Content.Card.CTAUrl.Text %}
+{% assign ctaLabel = Model.ContentItem.Content.Card.CTALabel.Text %}
 {% assign id = Model.ContentItem.Content.HtmlAttributesPart.Id %}
 {% assign mediaUrl = Model.ContentItem.Content.Card.Image.Paths[0] %}
 {% assign meta = Model.ContentItem.Content.Card.MetaText.Text %}
@@ -14,7 +15,7 @@
     {% assign tag = "a" %}
 {% endif %}
 
-{% assign cssClasses = "card card--equal-height" %}
+{% assign cssClasses = "card" %}
 
 {% if Model.ContentItem.Content.HtmlAttributesPart.CssClasses %}
     {% assign cssClasses = cssClasses | append: " " | append: Model.ContentItem.Content.HtmlAttributesPart.CssClasses %}
@@ -65,5 +66,11 @@
         </header>
         
         {{ Model.Content.Body | shape_render }}
+
+        {% if url != nil and ctaLabel != nil %}
+            <span class="btn btn--fake btn--primary">
+                {{ ctaLabel }}
+            </span>
+        {% endif %}
     </div>
 </{{tag}}>


### PR DESCRIPTION
Per 284-card-widget-template-doesnt-match-default-definitions. 

Meta text was in the template (but not part of the defintion), the template was looking for a differently named URL field, and didn't handle a CTA label at all (which is in the definition).

Also removed the attempt at equalheighting as standard, as I think just having a card be it's own height is a more sensible default than trying to eqh with whatever is adjacent to it, which in some cases will not even be another card in the case of this widget which is used directly in flows.