### PR TITLE
Inverted helper class

### DIFF
--- a/Views/Content-CarouselItem.liquid
+++ b/Views/Content-CarouselItem.liquid
@@ -10,7 +10,7 @@
 {% endif %}
 
 {% if invertColour %}
-    {% assign cssClasses = cssClasses | append: " carousel__item-body--inverted" %}
+    {% assign cssClasses = cssClasses | append: " carousel__item-body--inverted inverted" %}
 {% endif %}
 
 {% assign styles = "" %}

--- a/Views/Widget-Banner.liquid
+++ b/Views/Widget-Banner.liquid
@@ -28,7 +28,7 @@
 {% endif %}
 
 {% if inverted %}
-    {% assign css = css | append: " header--inverted" %}
+    {% assign css = css | append: " header--inverted inverted" %}
 {% endif %}
 
 {% if position != nil and position != "" %}

--- a/Views/Widget-Card.liquid
+++ b/Views/Widget-Card.liquid
@@ -34,7 +34,7 @@
 {% endif %}
 
 {% if invertColour %}
-    {% assign cssClasses = cssClasses | append: " card--inverted" %}
+    {% assign cssClasses = cssClasses | append: " card--inverted inverted" %}
 {% endif %}
 
 {% assign styles = "" %}

--- a/Views/Widget-ContentFeed.liquid
+++ b/Views/Widget-ContentFeed.liquid
@@ -33,7 +33,7 @@
 {% endif %}
 
 {% if invertColour %}
-    {% assign cssClasses = cssClasses | append: " content-feed--inverted" %}
+    {% assign cssClasses = cssClasses | append: " content-feed--inverted inverted" %}
 {% endif %}
 
 {% assign styles = "" %}

--- a/Views/Widget-FeaturedContent.liquid
+++ b/Views/Widget-FeaturedContent.liquid
@@ -22,7 +22,7 @@
 {% endif %}
 
 {% if invertColour %}
-    {% assign cssClasses = cssClasses | append: " content-feed--inverted" %}
+    {% assign cssClasses = cssClasses | append: " content-feed--inverted inverted" %}
 {% endif %}
 
 {% assign styles = "" %}

--- a/Views/Widget-Footer.liquid
+++ b/Views/Widget-Footer.liquid
@@ -9,7 +9,7 @@
 {% assign contentWidth = Model.ContentItem.Content.Footer.ContentWidth.Text %}
 
 {% if inverted %}
-    {% assign css = css | append: " footer--inverted" %}
+    {% assign css = css | append: " footer--inverted inverted" %}
 {% endif %}
 
 {% if backgroundFixed %}

--- a/Views/Widget-Group.liquid
+++ b/Views/Widget-Group.liquid
@@ -13,7 +13,7 @@
 {% endif %}
 
 {% if invertColour %}
-    {% assign cssClasses = cssClasses | append: " group--inverted" %}
+    {% assign cssClasses = cssClasses | append: " group--inverted inverted" %}
 {% endif %}
 
 {% if backgroundFixed %}

--- a/Views/Widget-Section.liquid
+++ b/Views/Widget-Section.liquid
@@ -63,7 +63,7 @@
 {% endif %}
 
 {% if invertColour %}
-    {% assign cssClasses = cssClasses | append: " section--inverted" %}
+    {% assign cssClasses = cssClasses | append: " section--inverted inverted" %}
 {% endif %}
 
 {% assign cssClasses = cssClasses | append: " " | append: gutterClass %}

--- a/Views/Widget-Tiles.liquid
+++ b/Views/Widget-Tiles.liquid
@@ -17,7 +17,7 @@
 {% endif %}
 
 {% if invertColour %}
-    {% assign cssClasses = cssClasses | append: " tiles--inverted" %}
+    {% assign cssClasses = cssClasses | append: " tiles--inverted inverted" %}
 {% endif %}
 
 {% if cols %}


### PR DESCRIPTION
An adjacent change is being made to the ThemeBP module that handles the CSS. The modifier classes remain and can still be used for bespoke inversion adaptions if desired, but this change means we can reduce repeated css rules and simplify some of the $class= logic in navs.