### PR TITLE
Improve section gutter output

### DIFF
--- a/Views/Widget-Section.liquid
+++ b/Views/Widget-Section.liquid
@@ -66,8 +66,6 @@
     {% assign cssClasses = cssClasses | append: " section--inverted inverted" %}
 {% endif %}
 
-{% assign cssClasses = cssClasses | append: " " | append: gutterClass %}
-
 {% assign cssClasses = cssClasses | append: " " | append: verticalGutterClass %}
 {% assign cssClasses = cssClasses | append: " " | append: stackedVerticalGutterClass %}
 


### PR DESCRIPTION
This just outputs the word 'default' or 'large' or 'none', and gutterClass is already handled elsewhere.