### PR TITLE
Add Logo and Logos widget content type

### DIFF
--- a/Etch.OrchardCore.Widgets.csproj
+++ b/Etch.OrchardCore.Widgets.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.4.7</Version>
+    <Version>1.5.0</Version>
     <PackageId>Etch.OrchardCore.Widgets</PackageId>
     <Title>Etch OrchardCore Widgets</Title>
     <Authors>Etch</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@
     Name = "Common Widgets",
     Author = "Etch",
     Website = "https://etchuk.com",
-    Version = "1.4.7"
+    Version = "1.5.0"
 )]
 
 [assembly: Feature(

--- a/Recipes/definitions.recipe.json
+++ b/Recipes/definitions.recipe.json
@@ -752,6 +752,8 @@
                     "Label",
                     "LegacyVisualEditor",
                     "Link",
+                    "Logo",
+                    "Logos",
                     "OrderedList",
                     "Paragraph",
                     "RadioButtons",
@@ -1359,6 +1361,77 @@
               "Settings": {
                 "ContentTypePartSettings": {
                   "Position": "2"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "Name": "Logo",
+          "DisplayName": "Logo",
+          "Settings": {
+            "ContentTypeSettings": {
+              "Stereotype": "Widget"
+            },
+            "Category": "Content",
+            "Description": "Display a small image, e.g a platform logo such as Steam or Xbox",
+            "Icon": "portrait"
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "TitlePart",
+              "Name": "TitlePart",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "0"
+                }
+              }
+            },
+            {
+              "PartName": "Logo",
+              "Name": "Logo",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "1"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "Name": "Logos",
+          "DisplayName": "Logos",
+          "Settings": {
+            "ContentTypeSettings": {
+              "Stereotype": "Widget"
+            },
+            "Category": "Content",
+            "Description": "Display a collection of Logo widgets.",
+            "Icon": "icons"
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "TitlePart",
+              "Name": "TitlePart",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "0"
+                }
+              }
+            },
+            {
+              "PartName": "BagPart",
+              "Name": "Items",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "DisplayName": "Logos",
+                  "Description": "Logos to be displayed in this widget",
+                  "Position": "1"
+                },
+                "BagPartSettings": {
+                  "ContainedContentTypes": [
+                    "Logo"
+                  ]
                 }
               }
             }
@@ -3643,6 +3716,53 @@
                   "Hint": "Specify descriptive alt text for the thumbnail image/video"
                 },
                 "ContentIndexSettings": {}
+              }
+            }
+          ]
+        },
+        {
+          "Name": "Logo",
+          "Settings": {},
+          "ContentPartFieldDefinitionRecords": [
+            {
+              "FieldName": "MediaField",
+              "Name": "Logo",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Logo",
+                  "Position": "1"
+                },
+                "MediaFieldSettings": {
+                  "Hint": "Image to be displayed",
+                  "Multiple": false
+                }
+              }
+            },
+            {
+              "FieldName": "LinkField",
+              "Name": "Link",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Link",
+                  "Position": "2"
+                },
+                "LinkFieldSettings": {
+                  "Hint": "Optionally add a link to this image"
+                }
+              }
+            },
+            {
+              "FieldName": "BooleanField",
+              "Name": "OpenInNewTab",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Open in new tab",
+                  "Position": "3"
+                },
+                "BooleanFieldSettings": {
+                  "Hint": "Whether a new tab is opened when user interacts with link.",
+                  "Label": "Open in new tab"
+                }
               }
             }
           ]

--- a/Views/Widget-Logo.liquid
+++ b/Views/Widget-Logo.liquid
@@ -1,0 +1,21 @@
+{% assign logo =  Model.ContentItem.Content.Logo.Logo.Paths[0] %}
+{% assign logoAltText =  Model.ContentItem.Content.Logo.Logo.MediaTexts[0] %}
+{% assign linkText = Model.ContentItem.Content.Logo.Link.Text %}
+{% assign openInNewTab = Model.ContentItem.Content.Logo.OpenInNewTab.Value %}
+{% assign url = Model.ContentItem.Content.Logo.Link.Url %}
+{% assign cssClasses = "logo" %}
+{% assign tag = "div" %}
+
+{% if url != nil %}
+	{% assign cssClasses = cssClasses | append:" logo--link" %}
+	{% assign tag = "a" %}
+{% endif %}
+
+{% if logo != null %}
+	<{{tag}} class="{{ cssClasses }}" 
+	{% if url != nil %} href="{{url}}" {% endif %}
+	{% if openInNewTab == true %} target="_blank" {% endif %}
+	{% if linkText != nil %} title="{{linkText}}" {% endif %}>
+		<img class="logo__image" src="{{ logo | asset_url | resize_url: width:100 }}" alt="{{ logoAltText }}" />
+	</{{tag}}>
+{% endif %}

--- a/Views/Widget-Logos.liquid
+++ b/Views/Widget-Logos.liquid
@@ -1,0 +1,6 @@
+<div class="logos">
+    <span class="logos__title">{{ Model.ContentItem | display_text }}</span>
+    <div class="logos__items">
+        {{ Model.Content | shape_render }}
+    </div>
+</div>


### PR DESCRIPTION
- Addition of the Logo and Logos widget to display  singular / multiple logos which also have the ability to redirect to chosen URL's (with the ability to select if it should open in the current tab or open a new tab) 
- Addition of the views to present the Logo / Logos