### PR TITLE
Remove hardset height and width from the carousel SVG

### DIFF
--- a/Views/Widget-Carousel.liquid
+++ b/Views/Widget-Carousel.liquid
@@ -4,12 +4,12 @@
 <div class="carousel js-carousel" data-duration="{{ Model.ContentItem.Content.Carousel.SlideDuration.Value | times: 1000 }}">
     {% if itemCount > 1 %}
         <button class="btn btn--icon carousel__previous-btn js-prev-btn">
-            <svg width="27" height="50" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path clip-rule="evenodd" d="M1.541 26.414L25.127 50l1.415-1.414L2.956 25 26.54 1.414 25.127 0 1.541 23.586l-.126-.127-1.414 1.415.126.126-.126.126 1.414 1.415.126-.127z" /></svg>
+            <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path clip-rule="evenodd" d="M1.541 26.414L25.127 50l1.415-1.414L2.956 25 26.54 1.414 25.127 0 1.541 23.586l-.126-.127-1.414 1.415.126.126-.126.126 1.414 1.415.126-.127z" /></svg>
             <span class="visually-hidden">{{ "Previous" | t }}</span>
         </button>
 
         <button class="btn btn--icon carousel__next-btn js-next-btn">
-            <svg width="27" height="50" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path clip-rule="evenodd" d="M1.541 26.414L25.127 50l1.415-1.414L2.956 25 26.54 1.414 25.127 0 1.541 23.586l-.126-.127-1.414 1.415.126.126-.126.126 1.414 1.415.126-.127z" /></svg>
+            <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path clip-rule="evenodd" d="M1.541 26.414L25.127 50l1.415-1.414L2.956 25 26.54 1.414 25.127 0 1.541 23.586l-.126-.127-1.414 1.415.126.126-.126.126 1.414 1.415.126-.127z" /></svg>
             <span class="visually-hidden">{{ "Next" | t }}</span>
         </button>
 


### PR DESCRIPTION
As we're now trending away from SVGs having hardset inline width/heights I have removed the hardset height and width from the svg. The height and width are now dictated using variables I have created in SCSS.