### PR TITLE
Rely on columns helper class

### DIFF
--- a/Views/Widget-Gallery.liquid
+++ b/Views/Widget-Gallery.liquid
@@ -3,7 +3,7 @@
 {% assign cols = Model.ContentItem.Content.ColumnablePart.Columns.Text %}
 
 {% if itemCount > 0 %}
-    <ul class="gallery gallery--{{cols}}-cols js-gallery">
+    <ul class="gallery gallery--{{cols}}-cols columns--{{cols}} js-gallery">
         {% for item in items %}
             {% assign itemShape = item | shape_build_display: "Detail" %}
             {% shape_add_properties itemShape ThumbnailAspectRatio: Model.ContentItem.Content.Gallery.ThumbnailAspectRatio.Text %}


### PR DESCRIPTION
An [adjacent PR](https://github.com/EtchUK/Etch.OrchardCore.ThemeBoilerplate/pull/261) adjusts the CSS in the ThemeBoilerplate so that Gallery doesn't need to have a re-implementation of column behaviour - it can use the `helpers/_columns.scss` helper classes instead. 

This change ensures the relevant helper classes are also output, and standardises the gallery with the way that other columnable widgets (like Content Feed and Tiles) work.