### PR TITLE
Heading improvements

### DIFF
--- a/Recipes/definitions.recipe.json
+++ b/Recipes/definitions.recipe.json
@@ -1897,34 +1897,38 @@
                   "Editor": "PredefinedList"
                 },
                 "TextFieldSettings": {
-                  "Hint": "Importance of the heading. The lower the value, the more important the heading.",
+                  "Hint": "Importance of the heading. The lower the value, the more important the heading. 'Paragraph' may be used to fake a heading, creating something which looks like a heading, but conveys no additional importance compared to other content on the page.",
                   "Required": true
                 },
                 "TextFieldPredefinedListEditorSettings": {
                   "Options": [
                     {
                       "name": "1",
-                      "value": "1"
+                      "value": "h1"
                     },
                     {
                       "name": "2",
-                      "value": "2"
+                      "value": "h2"
                     },
                     {
                       "name": "3",
-                      "value": "3"
+                      "value": "h3"
                     },
                     {
                       "name": "4",
-                      "value": "4"
+                      "value": "h4"
                     },
                     {
                       "name": "5",
-                      "value": "5"
+                      "value": "h5"
                     },
                     {
                       "name": "6",
-                      "value": "6"
+                      "value": "h6"
+                    },
+                    {
+                      "name": "Paragraph",
+                      "value": "p"
                     }
                   ],
                   "Editor": 1,
@@ -1942,7 +1946,7 @@
                   "Editor": "PredefinedList"
                 },
                 "TextFieldSettings": {
-                  "Hint": "By default, headings are styled according to their level. You can use this field to make them look like an alternative level of importance if necessary."
+                  "Hint": "By default, headings are styled according to their level. You can use this field to make them look like an alternative level of importance if necessary. 'Hidden' headings aren't visible to users, but are useful to screen readers and search engines"
                 },
                 "TextFieldPredefinedListEditorSettings": {
                   "Options": [
@@ -1952,27 +1956,31 @@
                     },
                     {
                       "name": "1",
-                      "value": "1"
+                      "value": "text--h1"
                     },
                     {
                       "name": "2",
-                      "value": "2"
+                      "value": "text--h2"
                     },
                     {
                       "name": "3",
-                      "value": "3"
+                      "value": "text--h3"
                     },
                     {
                       "name": "4",
-                      "value": "4"
+                      "value": "text--h4"
                     },
                     {
                       "name": "5",
-                      "value": "5"
+                      "value": "text--h5"
                     },
                     {
                       "name": "6",
-                      "value": "6"
+                      "value": "text--h6"
+                    },
+                    {
+                      "name": "Hidden",
+                      "value": "visually-hidden"
                     }
                   ],
                   "Editor": 1,

--- a/Views/Widget-Heading.liquid
+++ b/Views/Widget-Heading.liquid
@@ -7,14 +7,20 @@
 {% if Model.ContentItem.Content.HtmlAttributesPart.Id != null %}
     {% assign id = Model.ContentItem.Content.HtmlAttributesPart.Id %}
 {% endif %}
+
 {% if Model.ContentItem.Content.HtmlAttributesPart.CssClasses != null %}
     {% assign cssClasses = cssClasses | append: " " | append: Model.ContentItem.Content.HtmlAttributesPart.CssClasses %}
 {% endif %}
 
-{% if visualLevel != nil %}
-    {% assign cssClasses = cssClasses | append: " text--h" | append: visualLevel %}
+{% comment %} This check is included for backwards compatibility but should not be needed in future {% endcomment %}
+{% if level == "1" or level == "2" or level == "3" or level == "4" or level == "5" or level == "6" %}
+    {% assign level = "h" | append: level %}
 {% endif %}
 
-<h{{ level }} id="{{ id }}" class="{{ cssClasses }} {{ Model.ContentItem | animation_css }}" style="{{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}>
-    {{ text }}
-</h{{ level }}>
+{% if visualLevel != nil %}
+    {% assign cssClasses = cssClasses | append: " " | append: visualLevel %}
+{% endif %}
+
+<{{ level }} id="{{ id }}" class="{{ cssClasses }} {{ Model.ContentItem | animation_css }}" style="{{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}>
+    {{ text | raw }}
+</{{ level }}>


### PR DESCRIPTION
Allows for raw html by default, as well as supporting a paragraph type and hidden visual level. An adjacent PR includes content recipe changes to the theme boilerplate to account for the change in underlying data.