### PR TITLE
Alt text standardisation on image fields

### DIFF
--- a/Recipes/definitions.recipe.json
+++ b/Recipes/definitions.recipe.json
@@ -2070,23 +2070,10 @@
                   "DisplayName": "Image"
                 },
                 "MediaFieldSettings": {
+                  "AllowMediaText": true,
                   "Hint": "Image to be displayed.",
                   "Required": true,
                   "Multiple": false
-                },
-                "ContentIndexSettings": {}
-              }
-            },
-            {
-              "FieldName": "TextField",
-              "Name": "AlternateText",
-              "Settings": {
-                "ContentPartFieldSettings": {
-                  "DisplayName": "Alternate Text"
-                },
-                "TextFieldSettings": {
-                  "Hint": "Description of the appearance and function of the image.",
-                  "Required": true
                 },
                 "ContentIndexSettings": {}
               }
@@ -2741,20 +2728,13 @@
               "Settings": {
                 "ContentPartFieldSettings": {
                   "DisplayName": "Image"
+                },
+                "MediaFieldSettings": {
+                  "AllowMediaText": true,
+                  "Hint": "Image to be displayed on the card",
+                  "Required": false,
+                  "Multiple": false
                 }
-              }
-            },
-            {
-              "FieldName": "TextField",
-              "Name": "ImageAlternateText",
-              "Settings": {
-                "ContentPartFieldSettings": {
-                  "DisplayName": "Image Alternate Text"
-                },
-                "TextFieldSettings": {
-                  "Hint": "Description of the appearance and function of the image."
-                },
-                "ContentIndexSettings": {}
               }
             },
             {
@@ -3691,16 +3671,6 @@
                   "Multiple": false
                 }
               }
-            },
-            {
-              "FieldName": "TextField",
-              "Name": "AltText",
-              "Settings": {
-                "ContentPartFieldSettings": {
-                  "DisplayName": "Alt Text",
-                  "Position": "1"
-                }
-              }
             }
           ]
         },
@@ -3742,16 +3712,6 @@
                 "ContentPartFieldSettings": {
                   "DisplayName": "Title",
                   "Position": "1"
-                }
-              }
-            },
-            {
-              "FieldName": "TextField",
-              "Name": "ThumbnailAltText",
-              "Settings": {
-                "ContentPartFieldSettings": {
-                  "DisplayName": "Thumbnail Alt Text",
-                  "Position": "3"
                 }
               }
             }

--- a/Views/Content-GalleryEmbedItem.liquid
+++ b/Views/Content-GalleryEmbedItem.liquid
@@ -9,8 +9,10 @@
     {% assign thumb = thumb  | resize_url: width: 1280 %}
 {% endif %}
 
+{% assign altText = Model.ContentItem.Content.GalleryEmbedItem.ThumbnailAltText.Text | default: Model.ContentItem.Content.GalleryEmbedItem.ThumbnailImage.MediaTexts[0] %}
+
 <li class="gallery__item gallery__item--embed gallery__item--thumbnail-force-{{ Model.Properties.ThumbnailAspectRatio }}">
     <a class="gallery__item-link" href="{{ Model.ContentItem.Content.GalleryEmbedItem.EmbedURL.Text }}">
-        <img class="gallery__item-thumb" src="{{ thumb }}" title="{{ Model.ContentItem.Content.GalleryEmbedItem.Title.Text }}" alt="{{ Model.ContentItem.Content.GalleryEmbedItem.ThumbnailAltText.Text }}" />
+        <img class="gallery__item-thumb" src="{{ thumb }}" title="{{ Model.ContentItem.Content.GalleryEmbedItem.Title.Text }}" alt="{{ altText }}" loading="lazy" />
     </a>
 </li>

--- a/Views/Content-GalleryMediaItem.liquid
+++ b/Views/Content-GalleryMediaItem.liquid
@@ -9,8 +9,10 @@
     {% assign thumb = thumb  | resize_url: width: 1280 %}
 {% endif %}
 
+{% altText = Model.ContentItem.Content.GalleryMediaItem.AltText.Text | default: Model.ContentItem.Content.GalleryMediaItem.Image.MediaTexts[0] %}
+
 <li class="gallery__item gallery__item--media gallery__item--thumbnail-force-{{ Model.Properties.ThumbnailAspectRatio }}">
     <a class="gallery__item-link" href="{{ Model.ContentItem.Content.GalleryMediaItem.Image.Paths[0] | asset_url| resize_url: width: 2560 }}">
-        <img class="gallery__item-thumb" src="{{ thumb }}" title="{{ Model.ContentItem.Content.GalleryMediaItem.AltText.Text }}" alt="{{ Model.ContentItem.Content.GalleryMediaItem.AltText.Text }}" />
+        <img class="gallery__item-thumb" src="{{ thumb }}" title="{{ altText }}" alt="{{ altText }}" loading="lazy" />
     </a>
 </li>

--- a/Views/Widget-Card.liquid
+++ b/Views/Widget-Card.liquid
@@ -26,13 +26,15 @@
 
 {% if mediaUrl != blank %}
     {% assign cssClasses = cssClasses | append: " card--has-media" %}
-    {% assign assetURL = mediaUrl | asset_url | resize_url: width: 1024, height: 768, mode:'max' %}
+    {% assign assetURL = mediaUrl | asset_url | resize_url: width: 1280, height: 720, mode:'max' %}
 
     {% if mediaOverlay %}
         {% assign cssClasses = cssClasses | append: " card--media-overlay" %}
         {% assign assetURL = mediaUrl | asset_url | resize_url: width: 1024, height: 768, mode:'crop' %}
     {% endif %}
 {% endif %}
+
+{% assign altText = Model.ContentItem.Content.Card.ImageAlternateText.Text | default: Model.ContentItem.Content.Card.Image.MediaTexts[0] %}
 
 {% if backgroundFixed %}
     {% assign cssClasses = cssClasses | append: " bg--fixed" %}
@@ -62,7 +64,7 @@
 <{{tag}} {% if url != blank %}href="{{ url }}"{% endif %} {% if id != null %}id="{{ id }}"{% endif %} class="{{ cssClasses }} {{ Model.ContentItem | animation_css }}" style="{{ styles }} {{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}>
     {% if mediaUrl != blank %}
         <div class="card__media">
-            <img class="card__media-image" src="{{ assetURL }}" alt="{{ Model.ContentItem.Content.Card.ImageAlternateText.Text }}" loading="lazy" />
+            <img class="card__media-image" src="{{ assetURL }}" alt="{{ altText }}" loading="lazy" />
         </div>
     {% endif %}
 

--- a/Views/Widget-Image.liquid
+++ b/Views/Widget-Image.liquid
@@ -4,6 +4,7 @@
 
 {% assign linkTo = Model.ContentItem.Content.Image.LinkTo.Text %}
 {% assign imagePath = Model.ContentItem.Content.Image.Image.Paths[0] | asset_url | resize_url: width: 2560, mode:'min' %}
+{% assign altText = Model.ContentItem.Content.Image.AlternateText.Text | default: Model.ContentItem.Content.Image.Image.MediaTexts[0] %}
 
 {% if linkTo != blank %}
     {% assign tag = "a" %}
@@ -15,7 +16,7 @@
 {% endif %}
 
 <{{tag}} {% if linkTo != blank %}href="{{ linkTo }}"{% endif %} {% if id != blank %}id="{{ id }}"{% endif %} class="{{ cssClasses }} {{ Model.ContentItem | animation_css }}" style="{{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}>
-    <img src="{{ imagePath }}" alt="{{ Model.ContentItem.Content.Image.AlternateText.Text }}" loading="lazy" />
+    <img src="{{ imagePath }}" alt="{{ altText }}" loading="lazy" />
 </{{tag}}>
 
 


### PR DESCRIPTION
Also amended some crop/lazyloading behaviour for more sensible default values. 

I've used the default filter to provide some level of back compatibility for projects that still have the field -  which we did on the news when we changed alt text behaviour there. But I'll make a note for us to remove that in future.