### PR TITLE
Add support for liquid within widgets

### DIFF
--- a/Views/Widget-Html.liquid
+++ b/Views/Widget-Html.liquid
@@ -1,1 +1,1 @@
-{{ Model.ContentItem.Content.Html.Content.Value  | raw }}
+{{ Model.ContentItem.Content.Html.Content.Value  | liquid }}

--- a/Views/Widget-Paragraph.liquid
+++ b/Views/Widget-Paragraph.liquid
@@ -1,9 +1,9 @@
 {% assign id = Model.ContentItem.Content.HtmlAttributesPart.Id %}
 {% assign cssClasses = Model.ContentItem.Content.HtmlAttributesPart.CssClasses %}
-{% assign text = Model.ContentItem.Content.Paragraph.Text.Text %}
+{% assign text = Model.ContentItem.Content.Paragraph.Text.Text | liquid %}
 
 {% if Model.ContentItem.Content.HtmlAttributesPart != null %}
-    <p {% if id != null %} id="{{ id }}" {% endif %} class="{{ cssClasses }} {{ Model.ContentItem | animation_css }}" style="{{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}>{{ text | raw }}</p>
+    <p {% if id != null %} id="{{ id }}" {% endif %} class="{{ cssClasses }} {{ Model.ContentItem | animation_css }}" style="{{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}>{{ text }}</p>
 {% else %}
-    <p class="{{ Model.ContentItem | animation_css }}" style="{{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}>{{ text | raw }}</p>
+    <p class="{{ Model.ContentItem | animation_css }}" style="{{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}>{{ text }}</p>
 {% endif %}

--- a/Views/Widget-Text.liquid
+++ b/Views/Widget-Text.liquid
@@ -1,1 +1,1 @@
-{{ Model.ContentItem.Content.Text.Text.Text }}
+{{ Model.ContentItem.Content.Text.Text.Text | liquid }}


### PR DESCRIPTION
the ordered list and unordered list create a list of widgets, so I don't need to do anything to them as the widgets (paragraph, text and HTML) have the liquid filter added

I've removed raw from the code and replaced it with "liquid" as HTML is also valid liquid.