### PR TITLE
Visibility Part

### DIFF
--- a/Migrations.cs
+++ b/Migrations.cs
@@ -4,6 +4,7 @@ using Etch.OrchardCore.Fields.Colour.Fields;
 using Etch.OrchardCore.Fields.Colour.Settings;
 using Etch.OrchardCore.Fields.ResponsiveMedia.Fields;
 using Etch.OrchardCore.Fields.ResponsiveMedia.Settings;
+using Etch.OrchardCore.Widgets.Models;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentFields.Settings;
 using OrchardCore.ContentManagement.Metadata;
@@ -320,6 +321,44 @@ namespace Etch.OrchardCore.Widgets
             );
 
             return 8;
+        }
+
+        public int UpdateFrom8()
+        {
+            _contentDefinitionManager.AlterPartDefinition(nameof(VisibilityPart), builder => builder
+                 .Attachable()
+                 .WithDisplayName("Visibility")
+                 .WithDescription("Control when a content item is visible based on factors like screen size.")
+                 .WithDefaultPosition("20")
+                 .WithField(nameof(VisibilityPart.ResponsiveVisibility), field => field
+                    .WithDisplayName("Responsive Visibility")
+                    .OfType(nameof(TextField))
+                    .WithEditor("PredefinedList")
+                    .WithSettings(new TextFieldPredefinedListEditorSettings
+                    {
+                        DefaultValue = "",
+                        Editor = EditorOption.Dropdown,
+                        Options = new[]
+                        {
+                            new ListValueOption
+                            {
+                                Name = "Show at all sizes",
+                                Value = "",
+                            },
+                            new ListValueOption
+                            {
+                                Name = "Large screens only",
+                                Value = "responsive-display--large-only",
+                            },
+                            new ListValueOption
+                            {
+                                Name = "Small screens only",
+                                Value = "responsive-display--small-only",
+                            },
+                        },
+                    })));
+
+            return 9;
         }
     }
 }

--- a/Models/VisibilityPart.cs
+++ b/Models/VisibilityPart.cs
@@ -1,0 +1,10 @@
+﻿using OrchardCore.ContentFields.Fields;
+using OrchardCore.ContentManagement;
+
+namespace Etch.OrchardCore.Widgets.Models
+{
+    public class VisibilityPart : ContentPart
+    {
+        public TextField ResponsiveVisibility { get; set; }
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -16,6 +16,8 @@ namespace Etch.OrchardCore.Widgets
         public override void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc();
+
+            services.AddContentPart<VisibilityPart>();
             
             services.AddContentPart<HtmlAttributesPart>()
                 .UseDisplayDriver<HtmlAttributesPartDisplay>();
@@ -23,6 +25,7 @@ namespace Etch.OrchardCore.Widgets
             services.Configure<TemplateOptions>(o =>
             {
                 o.MemberAccessStrategy.Register<HtmlAttributesPart>();
+                o.MemberAccessStrategy.Register<VisibilityPart>();
             })
                 .AddLiquidFilter<AnimationCssFilter>("animation_css")
                 .AddLiquidFilter<AnimationDataAttributesFilter>("animation_data_attributes")

--- a/Views/Widget-Image.liquid
+++ b/Views/Widget-Image.liquid
@@ -15,6 +15,10 @@
     {% assign cssClasses = cssClasses | append: " " | append: Model.ContentItem.Content.HtmlAttributesPart.CssClasses %}
 {% endif %}
 
+{% if Model.ContentItem.Content.VisibilityPart.ResponsiveVisibility.Text != blank %}
+    {% assign cssClasses = cssClasses | append:" " | append: Model.ContentItem.Content.VisibilityPart.ResponsiveVisibility.Text %}
+{% endif %}
+
 <{{tag}} {% if linkTo != blank %}href="{{ linkTo }}"{% endif %} {% if id != blank %}id="{{ id }}"{% endif %} class="{{ cssClasses }} {{ Model.ContentItem | animation_css }}" style="{{ Model.ContentItem | animation_styles }}" {{ Model.ContentItem | animation_data_attributes }}>
     <img src="{{ imagePath }}" alt="{{ altText }}" loading="lazy" />
 </{{tag}}>

--- a/Views/Widget-VideoModal.liquid
+++ b/Views/Widget-VideoModal.liquid
@@ -1,4 +1,5 @@
 {% assign altText = Model.ContentItem.Content.VideoModal.AltText.Text %}
+{% assign cssClasses = "video-modal js-gallery" %}
 {% assign embedURL = Model.ContentItem.Content.VideoModal.ThumbnailVideo.Text %}
 {% assign imagePath = Model.ContentItem.Content.VideoModal.ThumbnailImage.Paths[0] %}
 {% assign text = Model.ContentItem.Content.VideoModal.Video.Text %}
@@ -6,8 +7,12 @@
 
 {% assign onClickEvent = Model.ContentItem.Content.JavaScriptEventsPart.OnClick.Value %}
 
+{% if Model.ContentItem.Content.VisibilityPart.ResponsiveVisibility.Text != blank %}
+    {% assign cssClasses = cssClasses | append:" " | append: Model.ContentItem.Content.VisibilityPart.ResponsiveVisibility.Text %}
+{% endif %}
+
 {% if url != nil %}
-<div class="video-modal js-gallery">
+<div class="{{ cssClasses }}">
     <a class="video-modal__link" href="{{ url }}" {% if onClickEvent !=nil%} onClick="{{ onClickEvent }}" {% endif %}>
         {% if embedURL != nil %}
             <div class="video-modal__media">

--- a/placement.json
+++ b/placement.json
@@ -13,86 +13,86 @@
     {
       "place": "Parts#Animation:35",
       "differentiator": "AnimationPart-Repeat",
-      "contentPart": ["AnimationPart"]
+      "contentPart": [ "AnimationPart" ]
     },
     {
       "place": "Parts#Background:17",
       "differentiator": "BackgroundPart-InvertTextColour",
-      "contentPart": ["BackgroundPart"]
+      "contentPart": [ "BackgroundPart" ]
     },
     {
       "place": "Parts#Background:17",
       "differentiator": "BackgroundPart-BackgroundFixed",
-      "contentPart": ["BackgroundPart"]
+      "contentPart": [ "BackgroundPart" ]
     },
     {
       "place": "Parts#Background:20",
       "differentiator": "BackgroundPart-BackgroundFill",
-      "contentPart": ["BackgroundPart"]
+      "contentPart": [ "BackgroundPart" ]
     },
     {
       "place": "Parts#Paging:9",
       "differentiator": "ContentFeed-Paging",
-      "contentType": ["ContentFeed"]
+      "contentType": [ "ContentFeed" ]
     },
     {
       "place": "Parts#Background:8",
       "differentiator": "Hero-AddGradient",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Background:7",
       "differentiator": "Hero-InvertColour",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Background:6",
       "differentiator": "Hero-LazyLoad",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Layout:1",
       "differentiator": "Hero-PullUp",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Misc:40",
       "differentiator": "Hero-ShowScrollEncouragement",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Layout:6",
       "differentiator": "Section-ReverseStackingOrder",
-      "contentType": ["Section"]
+      "contentType": [ "Section" ]
     },
     {
       "place": "Parts#Advanced:2",
       "differentiator": "Link-OpenInNewWindow",
-      "contentType": ["Link"]
+      "contentType": [ "Link" ]
     }
   ],
   "CodeField_Edit": [
     {
       "place": "Parts#Events:25",
       "differentiator": "JavaScriptEventsPart-OnClick",
-      "contentPart": ["JavaScriptEventsPart"]
+      "contentPart": [ "JavaScriptEventsPart" ]
     }
   ],
   "ColourField_Edit": [
     {
       "place": "Parts#Background:15",
       "differentiator": "BackgroundPart-BackgroundColour",
-      "contentPart": ["BackgroundPart"]
+      "contentPart": [ "BackgroundPart" ]
     },
     {
       "place": "Parts#Background:20",
       "differentiator": "Banner-MobileBackgroundColour",
-      "contentPart": ["Banner"]
+      "contentPart": [ "Banner" ]
     },
     {
       "place": "Parts#Background:1",
       "differentiator": "Hero-BackgroundColour",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     }
   ],
   "ColumnablePart": [
@@ -104,34 +104,34 @@
     {
       "place": "Parts#Menu:10",
       "differentiator": "Banner-Menu",
-      "contentType": ["Banner"]
+      "contentType": [ "Banner" ]
     }
   ],
   "NumericField_Edit": [
     {
       "place": "Parts#Animation:33",
       "differentiator": "AnimationPart-Delay",
-      "contentPart": ["AnimationPart"]
+      "contentPart": [ "AnimationPart" ]
     },
     {
       "place": "Parts#Animation:31",
       "differentiator": "AnimationPart-Duration",
-      "contentPart": ["AnimationPart"]
+      "contentPart": [ "AnimationPart" ]
     },
     {
       "place": "Parts#Paging:8",
       "differentiator": "ContentFeed-PageSize",
-      "contentType": ["ContentFeed"]
+      "contentType": [ "ContentFeed" ]
     },
     {
       "place": "Parts#Advanced:1",
       "differentiator": "Space-CustomSize",
-      "contentType": ["Space"]
+      "contentType": [ "Space" ]
     }
   ],
   "TextField": [
     {
-      "contentType": ["Group"],
+      "contentType": [ "Group" ],
       "place": "-"
     }
   ],
@@ -139,209 +139,219 @@
     {
       "place": "Parts#Animation:30",
       "differentiator": "AnimationPart-Type",
-      "contentPart": ["AnimationPart"]
+      "contentPart": [ "AnimationPart" ]
     },
     {
       "place": "Parts#Animation:32",
       "differentiator": "AnimationPart-Timing",
-      "contentPart": ["AnimationPart"]
+      "contentPart": [ "AnimationPart" ]
     },
     {
       "place": "Parts#Background:16",
       "differentiator": "BackgroundPart-BackgroundPattern",
-      "contentPart": ["BackgroundPart"]
+      "contentPart": [ "BackgroundPart" ]
     },
     {
       "place": "Parts#Menu:8",
       "differentiator": "Banner-MenuCloseButtonLabel",
-      "contentType": ["Banner"]
+      "contentType": [ "Banner" ]
     },
     {
       "place": "Parts#Menu:7",
       "differentiator": "Banner-MenuToggleButtonLabel",
-      "contentType": ["Banner"]
+      "contentType": [ "Banner" ]
     },
     {
       "place": "Parts#Background:22",
       "differentiator": "Banner-MobileBackgroundPattern",
-      "contentPart": ["Banner"]
+      "contentPart": [ "Banner" ]
     },
     {
       "place": "Parts#Style:10",
       "differentiator": "Banner-Position",
-      "contentType": ["Banner"]
+      "contentType": [ "Banner" ]
     },
     {
       "place": "Parts#Layout:14",
       "differentiator": "ColumnablePart-Columns",
-      "contentPart": ["ColumnablePart"]
+      "contentPart": [ "ColumnablePart" ]
     },
     {
       "place": "Parts#Layout:12",
       "differentiator": "ContentFeed-Columns",
-      "contentType": ["ContentFeed"]
+      "contentType": [ "ContentFeed" ]
     },
     {
       "place": "Parts#Layout:4",
       "differentiator": "Banner-ContentWidth",
-      "contentType": ["Banner"]
+      "contentType": [ "Banner" ]
     },
     {
       "place": "Parts#Layout:4",
       "differentiator": "Footer-ContentWidth",
-      "contentType": ["Footer"]
+      "contentType": [ "Footer" ]
     },
     {
       "place": "Parts#Layout:1",
       "differentiator": "Group-Style",
-      "contentType": ["Group"]
+      "contentType": [ "Group" ]
     },
     {
       "place": "Parts#Background:2",
       "differentiator": "Hero-BackgroundType",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Background:3",
       "differentiator": "Hero-BackgroundEmbed",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Size:4",
       "differentiator": "Hero-ContentWidth",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Layout:4",
       "differentiator": "Hero-Gutter",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Layout:2",
       "differentiator": "Hero-HorizontalAlignment",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Layout:3",
       "differentiator": "Hero-VerticalAlignment",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Layout:4",
       "differentiator": "Hero-VerticalAlignmentMobile",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Size:1",
       "differentiator": "Hero-AspectRatio",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Size:2",
       "differentiator": "Hero-AspectRatioTablet",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Size:3",
       "differentiator": "Hero-AspectRatioMobile",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Size:1",
       "differentiator": "Section-ContentWidth",
-      "contentType": ["Section"]
+      "contentType": [ "Section" ]
     },
     {
       "place": "Parts#Size:2",
       "differentiator": "Section-TopPadding",
-      "contentType": ["Section"]
+      "contentType": [ "Section" ]
     },
     {
       "place": "Parts#Size:3",
       "differentiator": "Section-BottomPadding",
-      "contentType": ["Section"]
+      "contentType": [ "Section" ]
     },
     {
       "place": "Parts#Size:4",
       "differentiator": "Section-SpacingAfter",
-      "contentType": ["Section"]
+      "contentType": [ "Section" ]
     },
     {
       "place": "Parts#Layout:1",
       "differentiator": "Section-Alignment",
-      "contentType": ["Section"]
+      "contentType": [ "Section" ]
     },
     {
       "place": "Parts#Layout:2",
       "differentiator": "Section-VerticalAlignment",
-      "contentType": ["Section"]
+      "contentType": [ "Section" ]
     },
     {
       "place": "Parts#Layout:3",
       "differentiator": "Section-Gutter",
-      "contentType": ["Section"]
+      "contentType": [ "Section" ]
     },
     {
       "place": "Parts#Layout:4",
       "differentiator": "Section-VerticalGutter",
-      "contentType": ["Section"]
+      "contentType": [ "Section" ]
     },
     {
       "place": "Parts#Layout:5",
       "differentiator": "Section-StackedVerticalGutter",
-      "contentType": ["Section"]
+      "contentType": [ "Section" ]
     },
     {
       "place": "Parts#Layout:1",
       "differentiator": "Gallery-ThumbnailAspectRatio",
-      "contentType": ["Gallery"]
+      "contentType": [ "Gallery" ]
     },
     {
       "place": "Parts#Advanced:3",
       "differentiator": "Heading-VisualLevel",
-      "contentType": ["Heading"]
+      "contentType": [ "Heading" ]
     },
     {
       "place": "Parts#Advanced:1",
       "differentiator": "RenderContent-ShapeDisplayOverride",
-      "contentType": ["RenderContent"]
+      "contentType": [ "RenderContent" ]
+    },
+    {
+      "place": "Parts#Visibility:20",
+      "differentiator": "VisibilityPart-ResponsiveVisibility",
+      "contentPart": [ "VisibilityPart" ]
     }
   ],
   "ResponsiveMediaField_Edit": [
     {
       "place": "Parts#Background:3",
       "differentiator": "Hero-BackgroundImage",
-      "contentType": ["Hero"]
+      "contentType": [ "Hero" ]
     },
     {
       "place": "Parts#Background:12",
       "differentiator": "Section-BackgroundImage",
-      "contentType": ["Section"]
+      "contentType": [ "Section" ]
     },
     {
       "place": "Parts#Bleed:20",
       "differentiator": "BleedPart-BleedIn",
-      "contentPart": ["BleedPart"]
+      "contentPart": [ "BleedPart" ]
     },
     {
       "place": "Parts#Bleed:21",
       "differentiator": "BleedPart-BleedOut",
-      "contentPart": ["BleedPart"]
+      "contentPart": [ "BleedPart" ]
     }
   ],
   "ResponsiveMediaField": [
     {
-      "contentType": ["Hero", "Section", "Carousel", "CarouselItem"],
+      "contentType": [ "Hero", "Section", "Carousel", "CarouselItem" ],
       "place": "Background"
     },
     {
-      "contentPart": ["BleedPart"],
+      "contentPart": [ "BleedPart" ],
       "place": "Content"
     }
   ],
   "TitlePart": [
     {
-      "contentType": ["Form", "Label"],
+      "contentType": [ "Form", "Label" ],
+      "place": "-"
+    }
+  ],
+  "VisibilityPart": [
+    {
       "place": "-"
     }
   ]


### PR DESCRIPTION
This part will be used to control whether a widget is visible based on factors like screen size. When attached to a content item, there will be a "Visibility" tab where content editors can control whether the widget displays all the time, large screens only or small screens only. By default the part isn't attached to any content types, however the likely candidates ("Image" & "VideoModal") have had their templates updated so if it's attached they support it out the box without needing to override the template.