### PR TITLE
Add shared gallery

### DIFF
--- a/Etch.OrchardCore.Widgets.csproj
+++ b/Etch.OrchardCore.Widgets.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="OrchardCore.Flows" Version="1.5.0" />
     <PackageReference Include="OrchardCore.Lists" Version="1.5.0" />
     <PackageReference Include="OrchardCore.Module.Targets" Version="1.5.0" />
+    <PackageReference Include="OrchardCore.Title" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -11,6 +11,6 @@
     Id = "Etch.OrchardCore.Widgets",
     Name = "Common Widgets",
     Description = "Provides widgets commonly found on web pages.",
-    Dependencies = new[] { "OrchardCore.Widgets", "OrchardCore.Flows", "OrchardCore.Html", "Etch.OrchardCore.Blocks", "Etch.OrchardCore.Fields.CodeField", "Etch.OrchardCore.Fields.ColourField", "Etch.OrchardCore.Fields.ResponsiveMedia", "OrchardCore.Layers" },
+    Dependencies = new[] { "OrchardCore.Widgets", "OrchardCore.Flows", "OrchardCore.Html", "Etch.OrchardCore.Blocks", "Etch.OrchardCore.Fields.CodeField", "Etch.OrchardCore.Fields.ColourField", "Etch.OrchardCore.Fields.ResponsiveMedia", "OrchardCore.Layers", "OrchardCore.Title" },
     Category = "Content"
 )]

--- a/Views/Content-SharedGallery.liquid
+++ b/Views/Content-SharedGallery.liquid
@@ -1,0 +1,7 @@
+﻿{% assign items = Model.ContentItem.Content.Items.ContentItems %}
+
+{% for item in items %}
+    {% assign itemShape = item | shape_build_display: "Detail" %}
+    {% shape_add_properties itemShape ThumbnailAspectRatio: Model.Properties.ThumbnailAspectRatio  %}
+    {{ itemShape | shape_render }}
+{% endfor %}

--- a/Views/Content-SharedGalleryItem.liquid
+++ b/Views/Content-SharedGalleryItem.liquid
@@ -1,0 +1,5 @@
+﻿{% assign sharedGalleries = Model.ContentItem.Content.SharedGalleryItem.SharedGallery.ContentItemIds | content_item_id %}
+
+{% assign itemShape = sharedGalleries[0] | shape_build_display: "Detail" %}
+{% shape_add_properties itemShape ThumbnailAspectRatio: Model.Properties.ThumbnailAspectRatio  %}
+{{ itemShape | shape_render }}


### PR DESCRIPTION
- The shared gallery will prove useful in situations of multiple localisations present on one site, it removes the need to add duplicate gallery widgets to each individual content item by referencing one shared gallery content item instead.